### PR TITLE
Add :: symbol to read from nems.configure.  Required for ESMF 8bs20+.

### DIFF
--- a/NUOPC/read_impexp_config_mod.F90
+++ b/NUOPC/read_impexp_config_mod.F90
@@ -164,7 +164,7 @@ module read_impexp_config_mod
 
 !   read export fields from config
     attrFF = NUOPC_FreeFormatCreate(fieldsConfig, &
-      label="ocn_export_fields", rc=rc)
+      label="ocn_export_fields::", rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, &
       msg=ESMF_LOGERR_PASSTHRU, CONTEXT)) return
     call NUOPC_FreeFormatGet(attrFF, lineCount=lineCount, rc=rc)
@@ -216,7 +216,7 @@ module read_impexp_config_mod
 
 !   read import fields from config
     attrFF = NUOPC_FreeFormatCreate(fieldsConfig, &
-      label="ocn_import_fields", rc=rc)
+      label="ocn_import_fields::", rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, &
       msg=ESMF_LOGERR_PASSTHRU, CONTEXT)) return
     call NUOPC_FreeFormatGet(attrFF, lineCount=lineCount, rc=rc)


### PR DESCRIPTION
This small change is required to update UFS to ESMF8bs20+.  This is due to an update in the NUOPC layer.  The change is backward compatible, so this can be tested with the current version of ESMF under UFS, which is ESMF8bs14.