### PR TITLE
HYCOM initialization fixes for UFS debugging

### DIFF
--- a/geopar.F90
+++ b/geopar.F90
@@ -673,6 +673,7 @@
 !
 !       assumes that reference states 1 and 3 are never next to each other.
 !
+        util2(:,:) = -99.0  !otherwise ii(jj)+1 to i(j)dm are NaN
         do j= 1,jj
           do i= 1,ii
             if     (max(util1(i,  j), &

--- a/mod_momtum.F90
+++ b/mod_momtum.F90
@@ -1679,6 +1679,8 @@
         enddo !i
         enddo !j
 !
+      dpmx(:,:) = 2.*cutoff  !otherwise ii(jj)+1 to i(j)dm are NaN
+!
       do 9 k=1,kk
 !
 ! --- store total (barotropic plus baroclinic) flow at old and mid time in
@@ -4021,6 +4023,8 @@
           vtotm(i,j)=0.0
         enddo !i
       enddo !j
+!
+      dpmx(:,:) = 2.*cutoff  !otherwise ii(jj)+1 to i(j)dm are NaN
 !
       do 9 k=1,kk
 !


### PR DESCRIPTION
Reinitialize arrays to avoid debugging NaN checks and allows for `-check all` during `CMAKE_Fortran_FLAGS_DEBUG`

**Issues Fixed**
Cases where array1(:,:) = array2(:,:) trips a run time NaN check when the active array size (ii,jj) is smaller than the actual array size (idm,jdm).  To avoid this, two arrays are reinitialized to non NaN values.

These changes were completed in collaboration with the NAVY HYCOM team.