### PR TITLE
Momentum flux fix for HAFS FV3ATM-HYCOM coupling

### DIFF
--- a/NUOPC/hycom_couple.F90
+++ b/NUOPC/hycom_couple.F90
@@ -538,7 +538,10 @@ module hycom_couple
       do i=1, ii
 !       imp_taux(i,j,1)=mgrid(i,j)
         if (ishlf(i,j).eq.1) then
-          imp_taux(i,j,1)=impData(i+i0,j+j0)
+!         The momentum flux received from CMEPS/FV3ATM are from sea to air (friction to air).
+!         However, the momentum flux expected and used in HYCOM should be air to sea (wind stress).
+!         Thus, we need to reverse the sign when retrieving taux/y.
+          imp_taux(i,j,1)=-impData(i+i0,j+j0)
         else
           imp_taux(i,j,1)=0.0
         endif
@@ -554,7 +557,10 @@ module hycom_couple
       do j=1, jja
       do i=1, ii
         if (ishlf(i,j).eq.1) then
-          imp_tauy(i,j,1)=impData(i+i0,j+j0)
+!         The momentum flux received from CMEPS/FV3ATM are from sea to air (friction to air).
+!         However, the momentum flux expected and used in HYCOM should be air to sea (wind stress).
+!         Thus, we need to reverse the sign when retrieving taux/y.
+          imp_tauy(i,j,1)=-impData(i+i0,j+j0)
           if (impData(i+i0,j+j0).ne.fill_value) then
 !           rotate taux and tauy to (x,y)ward
 !           assumes rotation only needed for impData


### PR DESCRIPTION
Fix to correctly use momentum flux received from CMEPS/FV3ATM for HAFS HYCOM coupling. The momentum flux received from CMEPS/FV3ATM are from sea to air (friction to air). Whereas, the momentum flux expected and used in HYCOM should be air to sea (wind stress). Thus, we need to reverse the sign when retrieving taux/y in NUOPC/hycom_couple.F90.