### PR TITLE
Correct/fix the symbolic link for ALT_CODE/README.src.dimensions

### DIFF
--- a/ALT_CODE/README.src.dimensions
+++ b/ALT_CODE/README.src.dimensions
@@ -1,1 +1,1 @@
-../../README.src/README.src.dimensions
+../README.src/README.src.dimensions


### PR DESCRIPTION
Correct the symbolic link for ALT_CODE/README.src.dimensions.

Simply, updating the symbolic link from
README.src.dimensions -> ../../README.src/README.src.dimensions
into
README.src.dimensions -> ../README.src/README.src.dimensions
inside the ALT_CODE can fix the issue.

Fix issue #5
